### PR TITLE
Fixed issue where IsSourceDisabledInErrors is still setting file info

### DIFF
--- a/src/Shouldly.Shared/Internals/SourceCodeTextGetter.cs
+++ b/src/Shouldly.Shared/Internals/SourceCodeTextGetter.cs
@@ -29,10 +29,9 @@ namespace Shouldly.Internals
 
         public string GetCodeText(object actual, StackTrace stackTrace)
         {
-            ParseStackTrace(stackTrace);
-
             if (ShouldlyConfiguration.IsSourceDisabledInErrors())
                 return actual.ToStringAwesomely();
+            ParseStackTrace(stackTrace);
             return GetCodePart();
         }
 


### PR DESCRIPTION
I realised I have a bug in my `IsSourceDisabledInErrors`. It is only affecting the dynamic tests, but with this change you can see the issue and why I disabled the tests
